### PR TITLE
Please merge: fixed a bug caused by wrong parsing

### DIFF
--- a/vc870-decode/vc870_decode.pl
+++ b/vc870-decode/vc870_decode.pl
@@ -27,7 +27,7 @@ my %fun_sel = (
 );
 
 while (<STDIN>) {
-    my @ivals = /^(\d{2})(\d)(\d{5})(\d{5})(\d{2})(\d)(\d)(\d)(\d)(\d)(\d)/;
+    my @ivals = /^(\d{2})(\d)(\d{5})(\d{5})(\d{2})(.)(.)(.)(.)(.)(\d)/;
     if (not defined($ivals[0])) {
         next;
     }
@@ -175,12 +175,12 @@ while (<STDIN>) {
         $div2 = $div;
     }
 
-    my $status = $ivals[5];
-    my $option1 = $ivals[6];
-    my $option2 = $ivals[7];
-    my $option3 = $ivals[8];
-    my $option4 = $ivals[9];
-    my $option5 = $ivals[10];
+    my $status  = ord($ivals[5]);
+    my $option1 = ord($ivals[6]);
+    my $option2 = ord($ivals[7]);
+    my $option3 = ord($ivals[8]);
+    my $option4 = ord($ivals[9]);
+    my $option5 = ord($ivals[10]);
 
     my $sign2_flag = ($status & 0x08);
     my $sign1_flag = ($status & 0x04);


### PR DESCRIPTION
Hi,

thanks for your repository. I am using it to read from my VC870. Unfortunately, the tool stopped printing out lines after enabling the backlight. The reason was that the respective value '5' turned into a '=' because the bit set by the backlight represents value 8. Thus, I modified your PERL script a little to deal with all 4 bits correctly.

Kind regards,
Florian
